### PR TITLE
created command line arg for S3 creds and removed hardcoded creds script

### DIFF
--- a/priors/sos/Sos.py
+++ b/priors/sos/Sos.py
@@ -11,9 +11,6 @@ from netCDF4 import Dataset, stringtochar
 import numpy as np
 import s3fs
 
-# Local imports
-from priors.sos.conf import confluence_creds
-
 class Sos:
     """Class that represents the SoS and required ops to create a new version.
     
@@ -61,7 +58,7 @@ class Sos:
     MOD_TIME = 7200
     VERS_LENGTH = 4
 
-    def __init__(self, continent, run_type, sos_dir):
+    def __init__(self, continent, run_type, sos_dir, confluence_creds):
         """
         Parameters
         ----------

--- a/priors/sos/conf.py
+++ b/priors/sos/conf.py
@@ -1,5 +1,0 @@
-confluence_creds = {
-    "key" : "",
-    "secret" : "",
-    "region" : ""
-}


### PR DESCRIPTION
Previously, the s3 creds were an empty python script that were read in as a local import in Sos.py. This made it so that you would need to store creds in the image. I followed convention (this is the same way we are doing this in the output module) by adding the S3 creds as an argument.