### PR TITLE
created command line arg for S3 creds and removed hardcoded creds script

### DIFF
--- a/priors/sos/Sos.py
+++ b/priors/sos/Sos.py
@@ -36,6 +36,8 @@ class Sos:
         path to SoS directory on local storage
     sos_file: Path
         path to SoS file
+    confluence_creds: dict
+            Dictionary of s3 credentials 
     SUFFIX: str
         ending name of the SoS
     VERS_LENGTH: int
@@ -68,6 +70,8 @@ class Sos:
             'constrained' or 'unconstrained' data product type
         sos_dir: Path
             path to SoS directory on local storage
+        confluence_creds: dict
+            Dictionary of s3 credentials 
         """
 
         self.bad_prior = np.array([])

--- a/priors/sos/Sos.py
+++ b/priors/sos/Sos.py
@@ -11,9 +11,6 @@ from netCDF4 import Dataset, stringtochar
 import numpy as np
 import s3fs
 
-# Local imports
-from priors.sos.conf import confluence_creds
-
 class Sos:
     """Class that represents the SoS and required ops to create a new version.
     
@@ -61,7 +58,7 @@ class Sos:
     MOD_TIME = 7200
     VERS_LENGTH = 4
 
-    def __init__(self, continent, run_type, sos_dir):
+    def __init__(self, continent, run_type, sos_dir, confluence_creds):
         """
         Parameters
         ----------

--- a/priors/sos/conf.py
+++ b/priors/sos/conf.py
@@ -1,5 +1,0 @@
-confluence_creds = {
-    "key" : "",
-    "secret" : "",
-    "region" : ""
-}

--- a/update_priors.py
+++ b/update_priors.py
@@ -171,8 +171,9 @@ def main():
 
     # Store command line arguments
     try:
-        run_type = sys.argv[1]
-        prior_ops = sys.argv[2:]
+        s3_creds_filename = sys.argv[1]
+        run_type = sys.argv[2]
+        prior_ops = sys.argv[3:]
         print(f"Running on {run_type} data product and pulling the following: {', '.join(prior_ops)}")
     except IndexError:
         print("Please enter appropriate command line arguments which MUST include run_type.")
@@ -184,8 +185,12 @@ def main():
     with open(INPUT_DIR / "continent.json") as jsonfile:
         cont = list(json.load(jsonfile)[index].keys())[0]
 
+    # Get s3 creds for SoS upload
+    with open(INPUT_DIR / s3_creds_filename) as jsonfile:
+        confluence_creds = json.load(jsonfile)
+
     # Retrieve and update priors
-    priors = Priors(cont, run_type, prior_ops, INPUT_DIR, INPUT_DIR / "sos")
+    priors = Priors(cont, run_type, prior_ops, INPUT_DIR, INPUT_DIR / "sos", confluence_creds)
     priors.update()
 
 if __name__ == "__main__":

--- a/update_priors.py
+++ b/update_priors.py
@@ -63,7 +63,7 @@ class Priors:
 
     """
 
-    def __init__(self, cont, run_type, priors_list, input_dir, sos_dir):
+    def __init__(self, cont, run_type, priors_list, input_dir, sos_dir, confluence_creds):
         """
         Parameters
         ----------
@@ -76,7 +76,9 @@ class Priors:
         input_dir: Path
             path to input data directory
         sos_dir: Path
-            path to SoS directory on local storage        
+            path to SoS directory on local storage
+        confluence_creds: dict
+            Dictionary of s3 credentials            
         """
 
         self.cont = cont
@@ -84,6 +86,7 @@ class Priors:
         self.priors_list = priors_list
         self.input_dir = input_dir
         self.sos_dir = sos_dir
+        self.confluence_creds = confluence_creds
 
     def execute_gbpriors(self, sos_file):
         """Create and execute GBPriors operations.
@@ -137,7 +140,7 @@ class Priors:
 
         # Create SoS object to manage SoS operations
         print("Copy and create new version of the SoS.")
-        sos = Sos(self.cont, self.run_type, self.sos_dir)
+        sos = Sos(self.cont, self.run_type, self.sos_dir, self.confluence_creds)
         sos.copy_sos()
         sos.create_new_version()
         sos_file = sos.sos_file


### PR DESCRIPTION
Previously, the s3 creds were an empty python script that were read in as a local import in Sos.py. This made it so that you would need to store creds in the image. I followed convention (this is the same way we are doing this in the output module) by adding the S3 creds as an argument.