### PR TITLE
variable creation bugfix

### DIFF
--- a/priors/gbpriors/GBPriorsUpdate.py
+++ b/priors/gbpriors/GBPriorsUpdate.py
@@ -64,13 +64,30 @@ class GBPriorsUpdate:
             SOS dataset to write to
         """
         
-        oi = sos["gbpriors"]["reach"].createVariable("overwritten_indexes", "i4", ("num_reaches",))
-        oi.comment = "Indexes of geoBAM priors that were overwritten."
-        oi[:] = self.gb_dict["reach"]["overwritten_indexes"]
+        # Try excepts here because the variables are only created once
+        try:
+            oi = sos["gbpriors"]["reach"].createVariable("overwritten_indexes", "i4", ("num_reaches",))
+            oi.comment = "Indexes of geoBAM priors that were overwritten."
+            oi[:] = self.gb_dict["reach"]["overwritten_indexes"]
+        except:
+            oi = sos["gbpriors"]["reach"]["overwritten_indexes"]
+            print('sos',oi)
+            print('new', len(self.gb_dict["reach"]["overwritten_indexes"]))
+            oi[:] = [self.gb_dict["reach"]["overwritten_indexes"]]
+            print('sos', oi)
+
+
         
-        oi = sos["gbpriors"]["node"].createVariable("overwritten_indexes", "i4", ("num_nodes",))
-        oi.comment = "Indexes of geoBAM priors that were overwritten."
-        oi[:] = self.gb_dict["node"]["overwritten_indexes"]
+        try:
+            oi = sos["gbpriors"]["node"].createVariable("overwritten_indexes", "i4", ("num_nodes",))
+            oi.comment = "Indexes of geoBAM priors that were overwritten."
+            oi[:] = self.gb_dict["node"]["overwritten_indexes"]
+
+        except:
+            oi = sos["gbpriors"]["node"]["overwritten_indexes"]
+            print('sos',oi)
+            print('new', len(self.gb_dict["node"]["overwritten_indexes"]))
+            oi[:] = [self.gb_dict["node"]["overwritten_indexes"]]
 
     def __update_level(self, grp, level):
         """Updates data in the SoS.

--- a/priors/gbpriors/GBPriorsUpdate.py
+++ b/priors/gbpriors/GBPriorsUpdate.py
@@ -65,29 +65,22 @@ class GBPriorsUpdate:
         """
         
         # Try excepts here because the variables are only created once
-        try:
+        if "overwritten_indexes" in sos["gbpriors"]["reach"].variables:
+            oi = sos["gbpriors"]["reach"]["overwritten_indexes"]
+            oi[:] = [self.gb_dict["reach"]["overwritten_indexes"]]
+        else:
             oi = sos["gbpriors"]["reach"].createVariable("overwritten_indexes", "i4", ("num_reaches",))
             oi.comment = "Indexes of geoBAM priors that were overwritten."
             oi[:] = self.gb_dict["reach"]["overwritten_indexes"]
-        except:
-            oi = sos["gbpriors"]["reach"]["overwritten_indexes"]
-            print('sos',oi)
-            print('new', len(self.gb_dict["reach"]["overwritten_indexes"]))
-            oi[:] = [self.gb_dict["reach"]["overwritten_indexes"]]
-            print('sos', oi)
-
-
         
-        try:
+        if "overwritten_indexes" in sos["gbpriors"]["node"].variables:
+            oi = sos["gbpriors"]["node"]["overwritten_indexes"]
+            oi[:] = [self.gb_dict["node"]["overwritten_indexes"]]
+
+        else:
             oi = sos["gbpriors"]["node"].createVariable("overwritten_indexes", "i4", ("num_nodes",))
             oi.comment = "Indexes of geoBAM priors that were overwritten."
             oi[:] = self.gb_dict["node"]["overwritten_indexes"]
-
-        except:
-            oi = sos["gbpriors"]["node"]["overwritten_indexes"]
-            print('sos',oi)
-            print('new', len(self.gb_dict["node"]["overwritten_indexes"]))
-            oi[:] = [self.gb_dict["node"]["overwritten_indexes"]]
 
     def __update_level(self, grp, level):
         """Updates data in the SoS.

--- a/priors/sos/Sos.py
+++ b/priors/sos/Sos.py
@@ -293,18 +293,30 @@ class Sos:
             sos NetCDF Dataset
         """
 
-        oi = sos["model"].createVariable("overwritten_indexes", "i4", ("num_reaches",))
-        oi.comment = "Indexes of GRADES priors that were overwritten."
+        try:
+            oi = sos["model"].createVariable("overwritten_indexes", "i4", ("num_reaches",))
+            oi.comment = "Indexes of GRADES priors that were overwritten."
+        except:
+            print("overwritten_indexes allready created")
+
+        try:    
+            sos["model"].createDimension("nchar", 4)
+            os = sos["model"].createVariable("overwritten_source", "S1", ("num_reaches", "nchar"))
+            os.comment = "Source of gage data that overwrote GRADES priors."
+        except:
+            print('overwritten_source already created')
         
-        sos["model"].createDimension("nchar", 4)
-        os = sos["model"].createVariable("overwritten_source", "S1", ("num_reaches", "nchar"))
-        os.comment = "Source of gage data that overwrote GRADES priors."
+        try:
+            bp = sos["model"].createVariable("bad_priors", "i4", ("num_reaches",))
+            bp.comment = "Indexes of invalid gage priors that were not overwritten."
+        except:
+            print("bad priors already created")
         
-        bp = sos["model"].createVariable("bad_priors", "i4", ("num_reaches",))
-        bp.comment = "Indexes of invalid gage priors that were not overwritten."
-        
-        bps = sos["model"].createVariable("bad_prior_source", "S1", ("num_reaches", "nchar"))
-        bps.comment = "Source of invalid gage priors."
+        try:
+            bps = sos["model"].createVariable("bad_prior_source", "S1", ("num_reaches", "nchar"))
+            bps.comment = "Source of invalid gage priors."
+        except:
+            print("bad_prior_source allready created")
 
     def upload_file(self):
         """Upload SoS file to S3 bucket."""

--- a/priors/sos/Sos.py
+++ b/priors/sos/Sos.py
@@ -98,26 +98,25 @@ class Sos:
     def copy_sos(self):
         """Copy the latest version of the SoS file to local storage."""
 
-        print('tried to copy sos')
-        # session = Session(aws_access_key_id=self.confluence_creds['key'],
-        #                 aws_secret_access_key=self.confluence_creds['secret'])
-        # s3 = session.resource('s3')
-        # bucket = s3.Bucket(name="confluence-sos")
-        # print([i for i in bucket.objects.filter(Prefix=f"{self.run_type}/")])
-        # dirs = list(set([str(obj.key).split('/')[1] for obj in bucket.objects.filter(Prefix=f"{self.run_type}/") if obj.key != "constrained/"]))
-        # dirs.sort()
-        # current = dirs[-1]
-        # obj = s3.Object(bucket_name="confluence-sos", key=f"{self.run_type}/{current}/{self.continent}{self.SUFFIX}_priors.nc")
+        session = Session(aws_access_key_id=self.confluence_creds['key'],
+                        aws_secret_access_key=self.confluence_creds['secret'])
+        s3 = session.resource('s3')
+        bucket = s3.Bucket(name="confluence-sos")
+        print([i for i in bucket.objects.filter(Prefix=f"{self.run_type}/")])
+        dirs = list(set([str(obj.key).split('/')[1] for obj in bucket.objects.filter(Prefix=f"{self.run_type}/") if obj.key != "constrained/"]))
+        dirs.sort()
+        current = dirs[-1]
+        obj = s3.Object(bucket_name="confluence-sos", key=f"{self.run_type}/{current}/{self.continent}{self.SUFFIX}_priors.nc")
         
-        # if current != "0000":
-        #     try:
-        #         if (datetime.now(timezone.utc) - obj.last_modified).seconds < self.MOD_TIME:
-        #             obj = self._locate_previous_version(dirs, current, s3)
-        #     except s3.meta.client.exceptions.ClientError as error:
-        #         obj = self._locate_previous_version(dirs, current, s3)
+        if current != "0000":
+            try:
+                if (datetime.now(timezone.utc) - obj.last_modified).seconds < self.MOD_TIME:
+                    obj = self._locate_previous_version(dirs, current, s3)
+            except s3.meta.client.exceptions.ClientError as error:
+                obj = self._locate_previous_version(dirs, current, s3)
         
-        # print(f"Downloading: {obj.key}")
-        # obj.download_file(f"{self.sos_dir}/{self.continent}{self.SUFFIX}.nc")
+        print(f"Downloading: {obj.key}")
+        obj.download_file(f"{self.sos_dir}/{self.continent}{self.SUFFIX}.nc")
         
     def _locate_previous_version(self, dirs, current, s3):
         """Locate the previous version of a file in the dirs list.

--- a/update_priors.py
+++ b/update_priors.py
@@ -166,9 +166,9 @@ class Priors:
             sos.overwrite_grades()
 
 
-        # # Upload priors results to S3 bucket
-        # print("Uploading new SoS priors version.")
-        # sos.upload_file()
+        # Upload priors results to S3 bucket
+        print("Uploading new SoS priors version.")
+        sos.upload_file()
 
 
 def main():

--- a/update_priors.py
+++ b/update_priors.py
@@ -166,9 +166,9 @@ class Priors:
             sos.overwrite_grades()
 
 
-        # Upload priors results to S3 bucket
-        print("Uploading new SoS priors version.")
-        sos.upload_file()
+        # # Upload priors results to S3 bucket
+        # print("Uploading new SoS priors version.")
+        # sos.upload_file()
 
 
 def main():


### PR DESCRIPTION
After the creation of SOS 0001 some variables have already been created in the SOS. This PR adds checks so we do not try and create the variables again. The gbpriors overwriting had to be reformatted to the correct dimension of the already existing group. Tested locally.