### PR TITLE
Unconstrained gauge pull, Riggs module working, historical gauge pull

### DIFF
--- a/priors/Riggs/RiggsPull.py
+++ b/priors/Riggs/RiggsPull.py
@@ -210,65 +210,19 @@ class RiggsPull:
     def pull(self):
         """Pulls riggs data and (?) and stores in usgs_dict."""
 
-        # #define date range block here
-        # ALLt=pd.date_range(start=self.start_date,end=self.end_date)
-
-
-
-        # gage_read = RiggsRead.RiggsRead(Riggs_targets = self.riggs_targets, cont = self.cont)
-
-        # datariggs, reachIDR, agencyR, RIGGScal = gage_read.read()
-    
-        # # Download records and gather a list of dataframes
-        # df_list = asyncio.run(self.gather_records(datariggs,agencyR))
-
         #define date range block here
         ALLt=pd.date_range(start='1980-1-1',end=self.end_date)
 
         # get all reachIDR's we want to pull from non historic list
         sos = Dataset(self.sos_file, 'a')
 
+        # this method of pulling in the gauge targets where we read the targets twice
+        # lets us pull gauges that are not in the historic_q group
         gage_read = RiggsRead(Riggs_targets = self.riggs_targets, cont = self.cont)
         # read in all gauges to create agencyR list
         datariggs, reachIDR, agencyR, RIGGScal = gage_read.read()
         current_group_agency_reach_ids = sos[agencyR[0]][f'{agencyR[0]}_reach_id'][:]
-        # print('cgari')
-        # print(current_group_agency_reach_ids)
-        # print(reachIDR)
         datariggs, reachIDR, agencyR, RIGGScal = gage_read.read(current_group_agency_reach_ids = current_group_agency_reach_ids)
-        # print('after')
-        # print(reachIDR)
-        # crossreff agecy R with historical q so we don't re-pull those gauges
-        # historic_q_group_agency_reach_ids = sos["historicQ"][agencyR[0]][f'{agencyR[0]}_reach_id'][:]
-        
-
-
-
-# fixing below
-
-        # this list is the list of indices that need to be removed from datarigs, reachidr, agencyr, and Riggscal
-        # print('historic q reach ids')
-        # print(historic_q_group_agency_reach_ids)
-
-        # print('type', type(historic_q_group_agency_reach_ids[0]))
-
-        # print('attempting to convert', reachIDR[0], 'to', "{:e}".format(int(reachIDR[0])))
-        # print('new type is', type("{:e}".format(int(reachIDR[0]))))
-        # historic_reach_id_indices = [i for i, z in enumerate(reachIDR) if float("{:e}".format(int(z))) in historic_q_group_agency_reach_ids]
-        # print('historics ind')
-        # print(historic_reach_id_indices)
-
-        # print('befor', len(reachIDR))
-
-        # # remove those indices from all lists before pulling records, need to do it in reverse so you dont change indices while deleting
-        # for i in sorted(historic_reach_id_indices, reverse=True):
-        #     for x in [datariggs, reachIDR, agencyR, RIGGScal]:
-        #         del x[i]
-        # print('after', len(reachIDR))
-        
-
-
-
 
         # Download records and gather a list of dataframes
         df_list = asyncio.run(self.gather_records(datariggs, agencyR))
@@ -280,10 +234,6 @@ class RiggsPull:
             riggs_qt = sos[agencyR[0]][f'{agencyR[0]}_qt']
             date_list = [days_convert(i) if i!=-999999999999.0 else i for i in riggs_qt[0].data]
             df_list = merge_historic_gauge_data(sos, date_list, df_list, agencyR[0])  
-
-
-
-
 
         # generate empty arrays for nc output
         EMPTY=np.nan

--- a/priors/Riggs/RiggsPull.py
+++ b/priors/Riggs/RiggsPull.py
@@ -323,5 +323,5 @@ class RiggsPull:
             "Mt": Mt,
             "P": P,
             "FDQS": FDQS,
-            "TwoYr": TwoYr,
+            "TwoYr": TwoYr
         }

--- a/priors/Riggs/RiggsPull.py
+++ b/priors/Riggs/RiggsPull.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 import rpy2.robjects as ro
 from os import walk
+from netCDF4 import Dataset, stringtochar
+import datetime as datetime
 
 #RpyImport necessary packages
 import rpy2.robjects as robjects
@@ -34,7 +36,61 @@ iserror = robjects.globalenv['is.error']
 substrRight = robjects.globalenv['substrRight']
 
 # Local imports
-from . import RiggsRead
+from .RiggsRead import RiggsRead
+
+
+
+
+
+
+def days_convert(days):
+
+
+    start_date = datetime.date(1, 1, 1)
+
+    new_date = start_date + datetime.timedelta(days=days)
+
+    return new_date.strftime('%Y-%m-%d %H:%M:%S+00:00')
+
+
+def create_sos_df(sos, date_list, index, agencyR):
+    df = pd.DataFrame(columns = ['datetime', '00060_Mean'])
+    riggs_q = sos[agencyR][f'{agencyR}_q']
+
+    df['datetime'] = date_list
+    df['00060_Mean'] = riggs_q[index]/0.0283168
+    df = df.set_index('datetime')
+
+    return df
+
+
+def combine_dfs(sos_df, gauge_df):
+    return sos_df.append(gauge_df)
+
+
+def merge_historic_gauge_data(sos, date_list, gauge_df_list, agencyR):
+
+    cnt = 0
+    for gauge_df in gauge_df_list:
+        if gauge_df.empty is False and '00060_Mean' in gauge_df:
+            try:
+                sos_df = create_sos_df(sos = sos, date_list = date_list, index = cnt, agencyR=agencyR)
+                merged_df = combine_dfs(sos_df = sos_df, gauge_df = gauge_df)
+                gauge_df_list[cnt] = merged_df
+                # print('merging', cnt, 'of', len(gauge_df_list))
+            
+            except:
+                print('merge failed')
+                print(gauge_df)
+                try:
+                    print(sos_df)
+                except:
+                    print('no sos df')
+        cnt +=1
+
+    return gauge_df_list
+
+
 
 class RiggsPull:
     """Class that pulls  Gage data and appends it to the SoS.
@@ -61,7 +117,7 @@ class RiggsPull:
     """
 
 
-    def __init__(self, riggs_targets, start_date, end_date):
+    def __init__(self, riggs_targets, start_date, end_date, cont, sos_file):
         """
         Parameters
         ----------
@@ -71,12 +127,16 @@ class RiggsPull:
             Date to start search for
         end_date: str
             Date to end search for
+        cont: str
+            String identifier for what continent the module is running on
         """
         
         self.riggs_targets = riggs_targets
         self.start_date = start_date
         self.end_date = end_date
         self.riggs_dict = {}
+        self.cont = cont
+        self.sos_file = sos_file
 
     async def get_record(self,site,agencyR):
         """Get rigs record.
@@ -150,14 +210,68 @@ class RiggsPull:
     def pull(self):
         """Pulls riggs data and (?) and stores in usgs_dict."""
 
+        # #define date range block here
+        # ALLt=pd.date_range(start=self.start_date,end=self.end_date)
+
+
+
+        # gage_read = RiggsRead.RiggsRead(Riggs_targets = self.riggs_targets, cont = self.cont)
+
+        # datariggs, reachIDR, agencyR, RIGGScal = gage_read.read()
+    
+        # # Download records and gather a list of dataframes
+        # df_list = asyncio.run(self.gather_records(datariggs,agencyR))
+
         #define date range block here
-        ALLt=pd.date_range(start=self.start_date,end=self.end_date)
-        # gage_read = RiggsRead(self.riggs_targets)
-        gage_read = RiggsRead.RiggsRead(self.riggs_targets)
+        ALLt=pd.date_range(start='1980-1-1',end=self.end_date)
+        gage_read = RiggsRead(Riggs_targets = self.riggs_targets, cont = self.cont)
         datariggs, reachIDR, agencyR, RIGGScal = gage_read.read()
+
+        # crossreff agecy R with historical q so we don't re-pull those gauges
+        sos = Dataset(self.sos_file, 'a')
+        historic_q_group_agency_reach_ids = sos["historicQ"][agencyR[0]][f'{agencyR[0]}_reach_id'][:]
         
+
+
+
+# fixing below
+
+        # this list is the list of indices that need to be removed from datarigs, reachidr, agencyr, and Riggscal
+        print('historic q reach ids')
+        print(historic_q_group_agency_reach_ids)
+
+        print('type', type(historic_q_group_agency_reach_ids[0]))
+
+        print('attempting to convert', reachIDR[0], 'to', "{:e}".format(int(reachIDR[0])))
+        print('new type is', type("{:e}".format(int(reachIDR[0]))))
+        historic_reach_id_indices = [i for i, z in enumerate(reachIDR) if float("{:e}".format(int(z))) in historic_q_group_agency_reach_ids]
+        print('historics ind')
+        print(historic_reach_id_indices)
+
+        print('befor', len(reachIDR))
+
+        # remove those indices from all lists before pulling records, need to do it in reverse so you dont change indices while deleting
+        for i in sorted(historic_reach_id_indices, reverse=True):
+            for x in [datariggs, reachIDR, agencyR, RIGGScal]:
+                del x[i]
+        print('after', len(reachIDR))
+        
+
+
+
+
         # Download records and gather a list of dataframes
-        df_list = asyncio.run(self.gather_records(datariggs,agencyR))
+        df_list = asyncio.run(self.gather_records(datariggs, agencyR))
+
+        # Bring in previously downloaded gauge data and merge with new data
+        
+        riggs_qt = sos[agencyR[0]][f'{agencyR[0]}_qt']
+        date_list = [days_convert(i) if i!=-999999999999.0 else i for i in riggs_qt[0].data]
+        df_list = merge_historic_gauge_data(sos, date_list, df_list, agencyR[0])  
+
+
+
+
 
         # generate empty arrays for nc output
         EMPTY=np.nan
@@ -247,5 +361,5 @@ class RiggsPull:
             "Mt": Mt,
             "P": P,
             "FDQS": FDQS,
-            "TwoYr": TwoYr
+            "TwoYr": TwoYr,
         }

--- a/priors/Riggs/RiggsRead.py
+++ b/priors/Riggs/RiggsRead.py
@@ -19,7 +19,7 @@ class RiggsRead:
         Reads Riggs data
     """
 
-    def __init__(self, Riggs_targets):
+    def __init__(self, Riggs_targets, cont):
         """
         Parameters
         ----------
@@ -28,13 +28,21 @@ class RiggsRead:
         """
 
         self.Riggs_targets = Riggs_targets
+        self.cont = cont
 
 
 
     def read(self):
         """Read Riggs data."""
-        filenames = next(walk(self.Riggs_targets), (None, None, []))[2]  # [] if no file
+        # filenames = next(walk(self.Riggs_targets), (None, None, []))[2]  # [] if no file
         #filenames = next(walk('./Rtarget/'), (None, None, []))[2]  # [] if no file
+
+        target_file_map = {
+            'na':['Riggs_Canada_P.nc']
+        }
+
+        filenames = target_file_map[self.cont]
+
         datariggs=[]
         reachIDR=[]
         agencyR=[]
@@ -43,8 +51,7 @@ class RiggsRead:
             ncf = Dataset(self.Riggs_targets.__str__()+"/"+filenames[i])
             #ncf = Dataset('./Rtarget/'+filenames[i])
            
-            #agency ID
-            print(ncf)          
+            #agency ID      
             st = ncf["StationID"][:].filled(np.nan)
             if type(st[0]) == np.ndarray:
                 st=np.rot90(st,k=-1,axes=(1,0))
@@ -82,6 +89,9 @@ class RiggsRead:
                 if 'Canada' in filenames[i]:
                      print('found canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
                      agencyR.append('WSC')
+
+                    #pull in sos here and only build the list based on the gauges that have allready been pulled
+
                      datariggs.append(str(st[j]))
                      reachIDR.append(str(int(rid[j])))
                      RIGGScal.append(int(cal[j]))
@@ -96,5 +106,4 @@ class RiggsRead:
                      datariggs.append(str(st[j]))
                      reachIDR.append(str(int(rid[j])))
                      RIGGScal.append(int(cal[j]))
-
         return datariggs, reachIDR, agencyR, RIGGScal

--- a/priors/Riggs/RiggsRead.py
+++ b/priors/Riggs/RiggsRead.py
@@ -32,7 +32,8 @@ class RiggsRead:
 
 
 
-    def read(self):
+
+    def read(self, current_group_agency_reach_ids = []):
         """Read Riggs data."""
         # filenames = next(walk(self.Riggs_targets), (None, None, []))[2]  # [] if no file
         #filenames = next(walk('./Rtarget/'), (None, None, []))[2]  # [] if no file
@@ -73,37 +74,73 @@ class RiggsRead:
             cal= ncf["CAL"][:].filled(np.nan)
             
             print(filenames)
+
+            ref_aray = np.array([str(int(i)) for i in rid]).astype(np.int64)
+
+
             for j in range(len(st)):
                 #this is set up for multiple agencies to run in the same module
                 #I may end up setting up independent modules for all of them meaning this can be simplified.
-                if 'brazil' in filenames[i]:
-                    agencyR.append('Hidroweb')
-                    datariggs.append(str(int(st[j])))
-                    reachIDR.append(str(int(rid[j])))
-                    RIGGScal.append(int(cal[j]))
-                if 'australia' in filenames[i]:
-                     agencyR.append('ABOM')
-                     datariggs.append(str(st[j]))
-                     reachIDR.append(str(int(rid[j])))
-                     RIGGScal.append(int(cal[j]))
-                if 'Canada' in filenames[i]:
-                     print('found canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
-                     agencyR.append('WSC')
 
-                    #pull in sos here and only build the list based on the gauges that have allready been pulled
 
-                     datariggs.append(str(st[j]))
-                     reachIDR.append(str(int(rid[j])))
-                     RIGGScal.append(int(cal[j]))
-                if 'japan' in filenames[i]:
-                    #some unserialize gages in the list so need to check for NaN                   
-                    agencyR.append('MLIT')
-                    datariggs.append(str(st[j]))
-                    reachIDR.append(str(int(rid[j])))
-                    RIGGScal.append(int(cal[j]))
-                if 'uk' in filenames[i]:
-                     agencyR.append('DEFRA')
-                     datariggs.append(str(st[j]))
-                     reachIDR.append(str(int(rid[j])))
-                     RIGGScal.append(int(cal[j]))
+                if len(current_group_agency_reach_ids)!=0:
+                    if ref_aray[j] in current_group_agency_reach_ids:
+
+                        if 'brazil' in filenames[i]:
+                            agencyR.append('Hidroweb')
+                            datariggs.append(str(int(st[j])))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'australia' in filenames[i]:
+                            agencyR.append('ABOM')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'Canada' in filenames[i]:
+                            # print('found canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+                            agencyR.append('WSC')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'japan' in filenames[i]:
+                            #some unserialize gages in the list so need to check for NaN                   
+                            agencyR.append('MLIT')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'uk' in filenames[i]:
+                            agencyR.append('DEFRA')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+
+                else:
+                        if 'brazil' in filenames[i]:
+                            agencyR.append('Hidroweb')
+                            datariggs.append(str(int(st[j])))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'australia' in filenames[i]:
+                            agencyR.append('ABOM')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'Canada' in filenames[i]:
+                            print('found canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+                            agencyR.append('WSC')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'japan' in filenames[i]:
+                            #some unserialize gages in the list so need to check for NaN                   
+                            agencyR.append('MLIT')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+                        if 'uk' in filenames[i]:
+                            agencyR.append('DEFRA')
+                            datariggs.append(str(st[j]))
+                            reachIDR.append(str(int(rid[j])))
+                            RIGGScal.append(int(cal[j]))
+
         return datariggs, reachIDR, agencyR, RIGGScal

--- a/priors/Riggs/RiggsRead.py
+++ b/priors/Riggs/RiggsRead.py
@@ -35,9 +35,8 @@ class RiggsRead:
 
     def read(self, current_group_agency_reach_ids = []):
         """Read Riggs data."""
-        # filenames = next(walk(self.Riggs_targets), (None, None, []))[2]  # [] if no file
-        #filenames = next(walk('./Rtarget/'), (None, None, []))[2]  # [] if no file
 
+        # add more file maps as we test new continents
         target_file_map = {
             'na':['Riggs_Canada_P.nc']
         }
@@ -82,7 +81,8 @@ class RiggsRead:
                 #this is set up for multiple agencies to run in the same module
                 #I may end up setting up independent modules for all of them meaning this can be simplified.
 
-
+                # This logic block ensures that the if we are in the second call of read
+                # then we will only read the targets of the non historic gauges
                 if len(current_group_agency_reach_ids)!=0:
                     if ref_aray[j] in current_group_agency_reach_ids:
 
@@ -97,7 +97,6 @@ class RiggsRead:
                             reachIDR.append(str(int(rid[j])))
                             RIGGScal.append(int(cal[j]))
                         if 'Canada' in filenames[i]:
-                            # print('found canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
                             agencyR.append('WSC')
                             datariggs.append(str(st[j]))
                             reachIDR.append(str(int(rid[j])))

--- a/priors/Riggs/RiggsRead.py
+++ b/priors/Riggs/RiggsRead.py
@@ -43,7 +43,8 @@ class RiggsRead:
             ncf = Dataset(self.Riggs_targets.__str__()+"/"+filenames[i])
             #ncf = Dataset('./Rtarget/'+filenames[i])
            
-            #agency ID            
+            #agency ID
+            print(ncf)          
             st = ncf["StationID"][:].filled(np.nan)
             if type(st[0]) == np.ndarray:
                 st=np.rot90(st,k=-1,axes=(1,0))
@@ -64,7 +65,7 @@ class RiggsRead:
             #calibration flag
             cal= ncf["CAL"][:].filled(np.nan)
             
-            
+            print(filenames)
             for j in range(len(st)):
                 #this is set up for multiple agencies to run in the same module
                 #I may end up setting up independent modules for all of them meaning this can be simplified.
@@ -79,6 +80,7 @@ class RiggsRead:
                      reachIDR.append(str(int(rid[j])))
                      RIGGScal.append(int(cal[j]))
                 if 'Canada' in filenames[i]:
+                     print('found canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
                      agencyR.append('WSC')
                      datariggs.append(str(st[j]))
                      reachIDR.append(str(int(rid[j])))

--- a/priors/Riggs/RiggsUpdate.py
+++ b/priors/Riggs/RiggsUpdate.py
@@ -78,6 +78,11 @@ class RiggsUpdate:
             self.map_dict["mean_q"] = self.Riggs_dict["Qmean"][indexes]
             self.map_dict["min_q"] = self.Riggs_dict["Qmin"][indexes]
             self.map_dict["tyr"] = self.Riggs_dict["TwoYr"][indexes]
+
+            # print(np.array(self.Riggs_dict["data"])[indexes])
+            # print(self.map_dict["Riggs_id"])
+
+
             self.map_dict["Riggs_id"] = np.array(self.Riggs_dict["data"])[indexes] # Changed from Riggsdata
             self.map_dict["Riggs_q"] = self.Riggs_dict["Qwrite"][indexes,:]
             self.map_dict["Riggs_qt"] = self.Riggs_dict["Twrite"][indexes,:]
@@ -105,12 +110,6 @@ class RiggsUpdate:
             Riggs = sos[agency]
             Riggs["num_days"][:] = self.map_dict["days"]
             # Riggs["num_Riggs_reaches"][:] = range(1, self.map_dict["Riggs_reach_id"].shape[0] + 1)
-            print(Riggs[f"{agency}_reach_id"][:])
-            print(self.map_dict["Riggs_reach_id"])
-
-            for element in self.map_dict["Riggs_reach_id"]:
-                if element not in Riggs[f"{agency}_reach_id"][:]:
-                    print(element)
 
 
 
@@ -121,7 +120,7 @@ class RiggsUpdate:
             Riggs["mean_q"][:] = np.nan_to_num(self.map_dict["mean_q"], copy=True, nan=self.FLOAT_FILL)
             Riggs["min_q"][:] = np.nan_to_num(self.map_dict["min_q"], copy=True, nan=self.FLOAT_FILL)
             Riggs["two_year_return_q"][:] = np.nan_to_num(self.map_dict["tyr"], copy=True, nan=self.FLOAT_FILL)
-            Riggs[f"{agency}_id"][:] = stringtochar(self.map_dict["Riggs_id"].astype("S16"))
+            Riggs[f"{agency}_id"][:] = stringtochar(self.map_dict["Riggs_id"].astype("S100"))
             Riggs[f"{agency}_q"][:] = np.nan_to_num(self.map_dict["Riggs_q"], copy=True, nan=self.FLOAT_FILL)
             Riggs[f"{agency}_qt"][:] = np.nan_to_num(self.map_dict["Riggs_qt"], copy=True, nan=self.FLOAT_FILL)
                 

--- a/priors/Riggs/RiggsUpdate.py
+++ b/priors/Riggs/RiggsUpdate.py
@@ -78,11 +78,6 @@ class RiggsUpdate:
             self.map_dict["mean_q"] = self.Riggs_dict["Qmean"][indexes]
             self.map_dict["min_q"] = self.Riggs_dict["Qmin"][indexes]
             self.map_dict["tyr"] = self.Riggs_dict["TwoYr"][indexes]
-
-            # print(np.array(self.Riggs_dict["data"])[indexes])
-            # print(self.map_dict["Riggs_id"])
-
-
             self.map_dict["Riggs_id"] = np.array(self.Riggs_dict["data"])[indexes] # Changed from Riggsdata
             self.map_dict["Riggs_q"] = self.Riggs_dict["Qwrite"][indexes,:]
             self.map_dict["Riggs_qt"] = self.Riggs_dict["Twrite"][indexes,:]

--- a/priors/Riggs/RiggsUpdate.py
+++ b/priors/Riggs/RiggsUpdate.py
@@ -65,6 +65,8 @@ class RiggsUpdate:
         same_ids = np.intersect1d(self.sos_reaches, Riggs_ids)
         indexes = np.where(np.isin(Riggs_ids, same_ids))[0]
 
+        print(' riggs q write', self.Riggs_dict["Qwrite"][0])
+
         if indexes.size == 0:
             self.map_dict = None
         else:
@@ -101,7 +103,7 @@ class RiggsUpdate:
             sos = Dataset(self.sos_file, 'a')
             sos.production_date = datetime.now().strftime('%d-%b-%Y %H:%M:%S')
 
-            Riggs = sos["model"]["Riggs"]
+            Riggs = sos["Riggs"]
             Riggs["num_days"][:] = self.map_dict["days"]
             Riggs["num_Riggs_reaches"][:] = range(1, self.map_dict["Riggs_reach_id"].shape[0] + 1)
             Riggs["Riggs_reach_id"][:] = self.map_dict["Riggs_reach_id"]

--- a/priors/Riggs/RiggsUpdate.py
+++ b/priors/Riggs/RiggsUpdate.py
@@ -64,7 +64,6 @@ class RiggsUpdate:
         Riggs_ids = self.Riggs_dict["reachId"]
         same_ids = np.intersect1d(self.sos_reaches, Riggs_ids)
         indexes = np.where(np.isin(Riggs_ids, same_ids))[0]
-        print(self.Riggs_dict.keys())
         
         if indexes.size == 0:
             self.map_dict = None
@@ -78,7 +77,7 @@ class RiggsUpdate:
             self.map_dict["mean_q"] = self.Riggs_dict["Qmean"][indexes]
             self.map_dict["min_q"] = self.Riggs_dict["Qmin"][indexes]
             self.map_dict["tyr"] = self.Riggs_dict["TwoYr"][indexes]
-            self.map_dict["Riggs_id"] = np.array(self.Riggs_dict["data"])[indexes] # Changed from Riggsdata
+            self.map_dict["Riggs_id"] = np.array(self.Riggs_dict["data"])[indexes]
             self.map_dict["Riggs_q"] = self.Riggs_dict["Qwrite"][indexes,:]
             self.map_dict["Riggs_qt"] = self.Riggs_dict["Twrite"][indexes,:]
     
@@ -104,10 +103,7 @@ class RiggsUpdate:
             agency = self.Riggs_dict["Agency"][0]
             Riggs = sos[agency]
             Riggs["num_days"][:] = self.map_dict["days"]
-            # Riggs["num_Riggs_reaches"][:] = range(1, self.map_dict["Riggs_reach_id"].shape[0] + 1)
-
-
-
+            # used f string for agency so it generalizes the sos creation for different agencies
             Riggs[f"{agency}_reach_id"][:] = self.map_dict["Riggs_reach_id"]
             Riggs["flow_duration_q"][:] = np.nan_to_num(self.map_dict["fdq"], copy=True, nan=self.FLOAT_FILL)
             Riggs["max_q"][:] = np.nan_to_num(self.map_dict["max_q"], copy=True, nan=self.FLOAT_FILL)

--- a/update_priors.py
+++ b/update_priors.py
@@ -147,19 +147,10 @@ class Priors:
         sos_file: Path
             path to SOS file to update
         """
-        print('running Rigs')
         Riggs_file = self.input_dir / "gage" / "Rtarget"
-        print('rigs file', Riggs_file)
         today = datetime.today().strftime("%Y-%m-%d")
         Riggs_pull = RiggsPull(Riggs_file, start_date=start_date, end_date=today, cont = self.cont,  sos_file = sos_file)
-
-        # need to update riggs pull, to not include historical gauge data 
-
-
         Riggs_pull.pull()
-        # filenames = next(walk(Riggs_file), (None, None, []))[2]
-        # print(filenames)
-        # Riggs_update = RiggsUpdate(sos_file, Riggs_pull.riggs_dict, Riggs_pull.agency_r)
         Riggs_update = RiggsUpdate(sos_file, Riggs_pull.riggs_dict)
         Riggs_update.read_sos()
         Riggs_update.map_data()
@@ -177,6 +168,8 @@ class Priors:
         sos_last_run_time = sos.last_run_time
 
         # Determine run type and add requested gage priors
+        # removed constrained run logic check as both unconstrained and constrained now pull gauge data
+        # in the future we should write the gauge data to a separate nc file for both
         if "grdc" in self.priors_list:
             print("Updating GRDC priors.")
             self.execute_grdc(sos_file)
@@ -193,6 +186,7 @@ class Priors:
             print("Updating geoBAM priors.")
             self.execute_gbpriors(sos_file)
 
+        # only overwrite if doing a constrained run
         if self.run_type == "constrained":
             # Overwrite GRADES with gage priors
             print("Overwriting GRADES data with gaged priors.")

--- a/update_priors.py
+++ b/update_priors.py
@@ -151,10 +151,15 @@ class Priors:
         Riggs_file = self.input_dir / "gage" / "Rtarget"
         print('rigs file', Riggs_file)
         today = datetime.today().strftime("%Y-%m-%d")
-        Riggs_pull = RiggsPull(Riggs_file, start_date=start_date, end_date=today)
+        Riggs_pull = RiggsPull(Riggs_file, start_date=start_date, end_date=today, cont = self.cont,  sos_file = sos_file)
+
+        # need to update riggs pull, to not include historical gauge data 
+
+
         Riggs_pull.pull()
-        filenames = next(walk(Riggs_file), (None, None, []))[2]
-        print(filenames)
+        # filenames = next(walk(Riggs_file), (None, None, []))[2]
+        # print(filenames)
+        # Riggs_update = RiggsUpdate(sos_file, Riggs_pull.riggs_dict, Riggs_pull.agency_r)
         Riggs_update = RiggsUpdate(sos_file, Riggs_pull.riggs_dict)
         Riggs_update.read_sos()
         Riggs_update.map_data()

--- a/update_priors.py
+++ b/update_priors.py
@@ -200,8 +200,8 @@ class Priors:
 
 
         # Upload priors results to S3 bucket
-        # print("Uploading new SoS priors version.")
-        # sos.upload_file()
+        print("Uploading new SoS priors version.")
+        sos.upload_file()
 
 
 def main():


### PR DESCRIPTION
This PR contains all changes that: allow the NA Riggs module to run, allow the unconstrained pipeline to pull the gauge data without overwriting it, and allow both Riggs and USGS pulling operations to only pull the gauge data since the pipeline was last ran.