### PR TITLE
Quality of life improvements for AWS and development runs

### DIFF
--- a/priors/gbpriors/GBPriorsGenerate.py
+++ b/priors/gbpriors/GBPriorsGenerate.py
@@ -345,25 +345,33 @@ class GBPriorsGenerate:
         cont = self.sos_dict["cont"]
         swot_files = [ Path(swot_file) for swot_file in glob.glob(f"{self.swot_dir}/{self.CONT_DICT[cont]}*_SWOT.nc") ]
 
+        cnt = 0
         for swot_file in swot_files:
-            print(f"Running on file: {swot_file.name}")     
-            reach_id = int(swot_file.name.split('_')[0])
-            sos_ri = np.where(self.sos_dict["reach_id"] == reach_id)
-            
-            qhat = self.sos_dict["qhat"][sos_ri[0]]
-            swot_data = extract_swot(swot_file, qhat)
-            if swot_data["reach"]:
-                gb = GB(swot_data["reach"])
-                data = gb.bam_data_reach()
-                priors = gb.bam_priors(data)
-                self.__extract_reach_priors(priors, reach_temp_dict, sos_ri)
-            
-            if swot_data["node"]:
-                gb = GB(swot_data["node"])
-                data = gb.bam_data_node()
-                priors = gb.bam_priors(data)
-                sos_ni = np.where(self.sos_dict["reach_node_id"] == reach_id)
-                self.__extract_node_priors(priors, node_temp_dict, sos_ri, sos_ni, swot_data["node"]["invalid_indexes"])
+            cnt +=1
+            if str(cnt).endswith('00'):
+                print('--------------------------------------', cnt, f'of {len(swot_files)} files processed ...')
+            try:
+                # print(f"Running on file: {swot_file.name}")     
+                reach_id = int(swot_file.name.split('_')[0])
+                sos_ri = np.where(self.sos_dict["reach_id"] == reach_id)
+                
+                qhat = self.sos_dict["qhat"][sos_ri[0]]
+                swot_data = extract_swot(swot_file, qhat)
+                if swot_data["reach"]:
+                    gb = GB(swot_data["reach"])
+                    data = gb.bam_data_reach()
+                    priors = gb.bam_priors(data)
+                    self.__extract_reach_priors(priors, reach_temp_dict, sos_ri)
+                
+                if swot_data["node"]:
+                    gb = GB(swot_data["node"])
+                    data = gb.bam_data_node()
+                    priors = gb.bam_priors(data)
+                    sos_ni = np.where(self.sos_dict["reach_node_id"] == reach_id)
+                    self.__extract_node_priors(priors, node_temp_dict, sos_ri, sos_ni, swot_data["node"]["invalid_indexes"])
+            except:
+                print(swot_file.name, 'failed')
+                pass
         
         self.gb_dict["reach"] = reach_temp_dict
         self.gb_dict["node"] = node_temp_dict

--- a/priors/sos/Sos.py
+++ b/priors/sos/Sos.py
@@ -82,7 +82,7 @@ class Sos:
         self.sos_file = None
         self.version = ""
 
-    def copy_sos(self):
+    def copy_sos(self, fake_current):
         """Copy the latest version of the SoS file to local storage."""
         
         s3 = boto3.client("s3")
@@ -93,6 +93,9 @@ class Sos:
         dirs.sort()
         print(f"Directories located for SoS: [{', '.join(dirs)}]")
         current = dirs[-1]
+
+        if fake_current != 'foo':
+            current = fake_current
         
         print(f"Locating: {self.run_type}/{current}/{self.continent}{self.SUFFIX}")
         response = s3.download_file(Bucket="confluence-sos", Key=f"{self.run_type}/{current}/{self.continent}{self.SUFFIX}", Filename=f"{self.sos_dir}/{self.continent}{self.SUFFIX}")

--- a/update_priors.py
+++ b/update_priors.py
@@ -66,7 +66,7 @@ class Priors:
 
     """
 
-    def __init__(self, cont, run_type, priors_list, input_dir, sos_dir):
+    def __init__(self, cont, run_type, priors_list, input_dir, sos_dir, fake_current):
         """
         Parameters
         ----------
@@ -87,6 +87,7 @@ class Priors:
         self.priors_list = priors_list
         self.input_dir = input_dir
         self.sos_dir = sos_dir
+        self.fake_current = fake_current
 
     def execute_gbpriors(self, sos_file):
         """Create and execute GBPriors operations.
@@ -159,7 +160,7 @@ class Priors:
         # Create SoS object to manage SoS operations
         print("Copy and create new version of the SoS.")
         sos = Sos(self.cont, self.run_type, self.sos_dir)
-        sos.copy_sos()
+        sos.copy_sos(self.fake_current)
         sos.create_new_version()
         sos_file = sos.sos_file
         sos_last_run_time = sos.last_run_time
@@ -216,6 +217,12 @@ def create_args():
                             nargs="+",
                             default=[],
                             help="List: usgs, grdc, riggs, gbpriors")
+
+    arg_parser.add_argument("-l",
+                            "--level",
+                            type=str,
+                            default='foo',
+                            help="Forces priors to pull a certain level sos ex: 0000")
     return arg_parser
 
 def main():
@@ -234,7 +241,7 @@ def main():
         cont = list(json.load(jsonfile)[i].keys())[0]
 
     # Retrieve and update priors
-    priors = Priors(cont, args.runtype, args.priors, INPUT_DIR, INPUT_DIR / "sos")
+    priors = Priors(cont, args.runtype, args.priors, INPUT_DIR, INPUT_DIR / "sos", args.level)
     priors.update()
 
 if __name__ == "__main__":


### PR DESCRIPTION
GB priors uses reach files to update the sos, sometimes these files have issues, previously GB priors would throw an error and stop the run entirely. I changed this behavior so that it just prints the problematic reach and moves on without updating priors for that reach.

I added a -l flag that allows you to choose what run number you want to start with eg: 0000. This is helpful for development so that we dont have to go to the s3 bucket and manually delete 0001 every time we run priors. This also bandaids a bug where AS was running so fast the other continents were looking at 0001 instead of 0000 for their input sos. This will be fixed in the future by setting a minimum time that a directory could be modified when looking for the sos.